### PR TITLE
docs: rewrite rwasm section using current rwasm docs

### DIFF
--- a/src/architecture/blended-vm/rwasm.md
+++ b/src/architecture/blended-vm/rwasm.md
@@ -1,168 +1,62 @@
-# rWASM
+# rWasm
 
-rWasm (reduced WebAssembly) is an EIP-3540 compatible binary IR of Wasm. It is designed to simplify the execution
-process of Wasm binaries while maintaining 99% compatibility with original Wasm features.
+rWasm is Fluent’s Wasm-derived execution substrate inside the blended VM architecture.
 
-rWasm is a specially modified binary IR of Wasm execution. It retains 99% compatibility with the original Wasm bytecode
-and instruction set but features a modified binary structure that avoids the pitfalls of non-zk friendly elements,
-without altering opcode behavior.
+Its role is to make heterogeneous execution more deterministic and proving-friendly while preserving a practical Wasm developer path.
 
-The main issue with Wasm is its use of relative offsets for type mappings, function mappings, and block/loop statements,
-which complicates the proving process. rWasm addresses this by adopting a more flattened binary structure without
-relative offsets and eliminating the need for a type mapping validator, allowing for straightforward execution.
+## Architectural role in Fluent
 
-The flattened structure of rWasm simplifies the process of proving the correctness of each opcode execution and places
-several verification steps in the hands of the developer. This modification makes rWasm a more efficient and zk-friendly
-option for integrating Web2 developers into the Web3 ecosystem.
+In Fluent’s blended model, rWasm is the execution representation that helps unify runtime behavior across different integration paths.
 
-## Technology
+At system level, this supports:
 
-Key Differences between rWasm and Wasm:
+- one shared state-transition model,
+- host-governed interruption/syscall boundaries,
+- deterministic commit semantics.
 
-- **Deterministic Function Order**: Functions are ordered based on their position in the codebase.
-- **Block/Loop Replacement**: Blocks and loops are replaced with Br-family instructions.
-- **Redesigned Break Instructions**: Break instructions now support program counter (PC) offsets instead of depth-level.
-- **Simplified Binary Verification**: Most sections are removed to streamline binary verification.
-- **Unified Memory Segment Section**: Implements all Wasm memory standards in one place.
-- **Removed Global Variables Section**: A global variables section is eliminated.
-- **Eliminated Type Mapping**: Type mapping is no longer necessary as the code is fully validated.
-- **Special Entrypoint Function**: A unique entry point function encompasses all segments.
+## Why rWasm instead of plain Wasm modules everywhere
 
-The new binary representation ensures a fully equivalently compatible Wasm runtime module from the binary.
-Some features are no longer supported by the rWasm runtime: module imports; global variables; memory imports;
-global variables export.
-These features are unnecessary as Fluent does not utilize them.
+Plain Wasm is developer-friendly but includes representation/runtime assumptions that are not always ideal for protocol-grade deterministic/proving workflows.
 
-## Structure
+rWasm addresses this by using:
 
-The rWasm binary format supports the following sections:
+- a constrained translation/execution model,
+- explicit module/runtime boundaries,
+- a dedicated opcode/runtime surface designed for predictable behavior.
 
-- **Bytecode Section**: Replaces the function/code/entrypoint sections.
-- **Memory Section**: Replaces memory/data sections for all active/passive/declare section types.
+## Current implementation shape (from `fluentlabs-xyz/rwasm`)
 
-The following sections, currently implemented, are scheduled for removal:
+### 1) Translation pipeline
 
-- **Function Section**: This section determines the size of each function and is used to properly allocate functions in
-  memory. Once the `CallInternal` opcode is eliminated, this section can be dropped as well.
-- **Element Section**: This section defines allocations for tables used in indirect calls. The `CallIndirect`
-  instruction is being phased out, and once this process is complete, the section will also be removed.
+Wasm input is validated and translated into a compact rWasm module consumed by the runtime.
 
-### Bytecode Section
+### 2) Module encoding contract
 
-This section consolidates Wasm's original function, code, and start sections. It contains all instructions for the
-entire binary without any additional separators for functions. Functions are recovered from the bytecode by reading the
-function section, which contains function lengths. The entrypoint function is injected at the end, which is used to
-initialize all segments according to Wasm constraints.
+rWasm modules use explicit header/versioning and ordered sections.
+This is treated as compatibility-sensitive wire format.
 
-> Note: The function section is planned to be removed and entrypoint stored at offset 0. To achieve this, eliminating
-> stack calls must be achieved while implementing indirect breaks. Although Fluent has an implementation for this, it is
-> not yet satisfactory, and a migration is planned to a register-based IR before finalizing it.
+### 3) Runtime VM + strategy layer
 
-### Memory & Data Section
+The runtime includes a native VM executor and a strategy abstraction for optional compatibility/comparison execution backends.
 
-In Wasm, memory and data sections are handled separately. In rWasm, the Memory section defines memory bounds (lower and
-upper limits), and data sections, which can be either active or passive, and specify data to be mapped inside memory.
-Unlike Wasm, rWasm eliminates the separate memory section, modifies the corresponding instruction logic, and merges all
-data sections.
+### 4) Fuel-first metering
 
-Here's an example of a WAT file that initializes memory with minimum and maximum memory bounds (default allocated memory
-is one page, and the maximum possible allocated pages are two):
+Fuel limits and consumption are explicit runtime controls, including deterministic out-of-fuel behavior.
 
-```wat
-(module
-  (memory 1 2)
-)
-```
+### 5) Optional tracing
 
-To support this, the `memory.grow` instruction is injected into the entrypoint to initialize the default memory.
-A special preamble is also added to all `memory.grow` instructions to perform upper bound checks.
+Tracing can capture execution/memory/table events for debugging and analysis pipelines.
 
-Here is an example of the resulting entrypoint injection:
+## Determinism and security boundary
 
-```wat
-(module
-  (func $__entrypoint
-    i32.const $_init_pages
-    memory.init
-    drop)
-)
-```
+rWasm determinism depends on both:
 
-According to Wasm standards, a memory overflow causes `u32::MAX` to be placed on the stack.
-For upper-bound checks, the `memory.size` opcode can be used. Here is an example of such an injection:
+- VM semantics, and
+- host import/syscall behavior.
 
-```wat
-(module
-  (func $_func_uses_memory_grow
-    (block
-      local.get 1
-      memory.size
-      i32.add
-      i32.const $_max_pages
-      i32.gts
-      drop
-      i32.const 4294967295
-      br 0
-      memory.grow)
-  )
-)
-```
+So runtime correctness requires deterministic host integration, not only deterministic opcode dispatch.
 
-These injections fully comply with Wasm standards, allowing Fluent to support official Wasm memory constraint checks for
-the memory section.
+## Status notes for readers
 
-For the data section, the process is more complex because Fluent needs to support three different data section types:
-
-- **Active**: Has a pre-defined compile-time offset.
-- **Passive**: Can be initialized dynamically at runtime.
-
-To address this, all sections are merged. If the memory is active, it is initialized inside the entrypoint with
-re-mapped offsets. Otherwise, the offset is remembered in a special mapping to adjust passive segments when the user
-calls `memory.init` manually.
-
-Here is an example of an entrypoint injection for an active data segment:
-
-```wat
-(module
-  (func $__entrypoint
-    i32.const $_relative_offset
-    i64.const $_data_offset
-    i64.const $_data_length // or u64::MAX in case of overflow
-    memory.init 0
-    data.drop $segment_index+1
-  )
-)
-```
-
-The data segment must be dropped finally. According to Wasm standards, once the segment is initialized, it must be
-entirely removed from memory. To simulate this behavior, Fluent uses zero segments as a default and stores special data
-segment flags to know which segments are still active.
-
-For passive data segments, the logic is similar, but data segment offsets must be recalculated on the fly.
-
-```wat
-(module
-  (func $_func_uses_memory_init
-    // adjust length
-    (block
-      local.get 1
-      local.get 3
-      i32.add
-      i32.const $_data_len
-      i32.gts
-      br_if_eqz 0
-      i32.const 4294967295 // an error
-      local.set 1
-    )
-    // adjust offset
-    i32.const $_data_offset
-    local.get 3
-    i32.add
-    local.set 2
-    // do init
-    memory.init $_segment_index+1
-  )
-)
-```
-
-*The provided injections are examples and may vary based on specific requirements.*
+- rWasm docs evolve with implementation; treat exact opcode and module-format details as version-sensitive.
+- For current production behavior, consult `fluentlabs-xyz/rwasm/docs/*` plus active Fluentbase/reth release docs.

--- a/src/rwasm/index.md
+++ b/src/rwasm/index.md
@@ -1,17 +1,56 @@
 # rWASM
 
-rWASM (reduced WebAssembly) is a Wasm-derived intermediary representation (IR) used by Fluent’s blended execution architecture.
+rWASM (reduced WebAssembly) is Fluent’s deterministic Wasm-derived execution representation and runtime stack.
 
-It is designed to simplify and constrain execution representation for deterministic runtime behavior and proving efficiency,
-while keeping practical compatibility with WebAssembly development flows.
+It is designed for environments that care about:
 
-## Key Features
+- predictable execution behavior,
+- explicit metering controls,
+- proving-friendly structure.
 
-- **ZK-friendliness**: a flatter and more constrained binary model than unrestricted Wasm module structure.
-- **Developer continuity**: keeps a Wasm-oriented workflow, so existing language/tooling ecosystems remain practical.
-- **Deterministic execution intent**: representation choices are made to support reproducible state-transition behavior.
+## What rWASM is (and is not)
 
-## Important Notice
+rWASM is **not** just a documentation alias for plain WebAssembly binaries.
+It is a constrained execution model with:
 
-rWASM is a protocol execution representation, not a generic drop-in replacement for every host Wasm use case.
-Always use current Fluent runtime/translator tooling and validation paths when producing or executing rWASM artifacts.
+- translation from Wasm inputs,
+- a compact module format,
+- a dedicated opcode/runtime model,
+- host import/syscall integration boundaries.
+
+At the same time, it keeps a Wasm-oriented developer path so existing tooling ecosystems remain practical.
+
+## Current source of truth
+
+For implementation-level details, use `fluentlabs-xyz/rwasm` docs first:
+
+- architecture,
+- pipeline,
+- module format,
+- VM/fuel behavior,
+- opcode specification,
+- security considerations.
+
+This tech-book chapter summarizes architecture intent.
+
+## Key architecture properties
+
+1. **Deterministic execution model**
+   - runtime semantics are designed for reproducible transitions.
+
+2. **Compact module representation**
+   - rWASM module encoding is structured for predictable runtime consumption.
+
+3. **Host boundary clarity**
+   - imports/syscalls are explicit integration points, not implicit ambient powers.
+
+4. **Fuel-aware execution**
+   - metering is a first-class runtime concern.
+
+5. **Strategy abstraction**
+   - native rWASM VM path and optional compatibility/backtesting strategy paths can coexist.
+
+## Reading map
+
+- [Motivation](motivation.md): why Fluent uses a reduced Wasm representation.
+- [Technology](technology.md): architecture-level mechanics (pipeline, module format, VM/fuel, feature gates).

--- a/src/rwasm/motivation.md
+++ b/src/rwasm/motivation.md
@@ -1,34 +1,41 @@
 # Motivation
 
-WebAssembly (WASM) is an interpreted language and binary format favored by many Web2 developers.
-Our approach aims to seamlessly integrate these developers into the Web3 world,
-despite the challenges this integration presents.
-We prefer WASM over RISC-V or other binary formats due to its well-established and widely adopted standard,
-which developers appreciate and support.
-Moreover, WASM includes a self-described binary format (covering memory structure, type mapping, and more),
-unlike RISC-V/AMD/Intel binary formats,
-which require binary wrappers like EXE or ELF.
+WebAssembly gives Fluent a strong developer bridge: mature language support, broad tooling, and well-understood execution semantics.
 
-However, WASM is not without its drawbacks,
-particularly its non-ZK friendly structures that complicate the proving process.
-This is where rWASM (Reduced WebAssembly) comes into play.
+But plain Wasm module/runtime assumptions are not automatically ideal for deterministic, proving-oriented blockchain execution.
 
-## Introducing rWASM
+## Problem Fluent is solving
 
-rWASM is a specially modified binary intermediary representation (IR) of WASM execution.
-It targets high compatibility with original WASM bytecode and instruction semantics,
-while using a modified binary structure that avoids non-ZK-friendly elements
-without changing core opcode behavior goals.
+If heterogeneous execution is handled as many isolated VM silos, proving and control-plane complexity grows quickly.
 
-The main issue with WASM is its use of relative offsets for type mappings, function mappings, and block/loop statements,
-which complicates the proving process.
-rWASM addresses this by adopting a more flattened binary structure without relative offsets
-and eliminating the need for a type mapping validator,
-allowing for straightforward execution.
+Fluent’s approach is to keep execution in one blended architecture and use rWASM as the Wasm-derived execution representation aligned with that model.
 
-## Benefits of rWASM
+## Why Wasm-derived instead of machine ISA-first
 
-The flattened structure of rWASM simplifies the process of proving the correctness of each opcode execution
-and places several verification steps in the hands of the developer.
-This modification makes rWASM a more efficient and ZK-friendly option
-for integrating Web2 developers into the Web3 ecosystem.
+Compared with low-level machine ISAs, Wasm offers:
+
+- better developer ecosystem reach,
+- cleaner portability story,
+- structured semantics that can be translated/constrained for deterministic execution.
+
+rWASM keeps these advantages while reshaping representation where needed for runtime determinism and proof ergonomics.
+
+## What rWASM changes conceptually
+
+At architecture level, rWASM aims to reduce execution-representation friction by:
+
+- flattening/normalizing control-flow and metadata patterns where useful,
+- reducing dependence on runtime-heavy mapping layers,
+- making module/runtime boundaries explicit.
+
+The objective is not “invent a new language,” but to make Wasm-family execution easier to govern and verify in Fluent’s protocol context.
+
+## Expected outcome
+
+rWASM helps Fluent combine:
+
+- Wasm-friendly developer onboarding,
+- deterministic host/runtime coordination,
+- proving-oriented execution structure.
+
+That combination is why rWASM is central to Fluent’s blended execution design.

--- a/src/rwasm/technology.md
+++ b/src/rwasm/technology.md
@@ -1,182 +1,94 @@
 # Technology
 
-rWASM is built on WASMi's intermediate representation (IR),
-originally developed by [Parity Tech](https://github.com/wasmi-labs/wasmi) and now under Robin Freyler's ownership.
-We chose the WASMi virtual machine because its IR is fully consistent with the original WebAssembly (WASM),
-ensuring compatibility and stability.
-For rWASM, we adhere to the same principles,
-making no changes to WASMi's IR and only modifying the binary representation to enhance ZK
-(ZK) friendliness.
+This chapter summarizes the current rWASM technology model as implemented in `fluentlabs-xyz/rwasm`.
 
-### Key Differences:
+## High-level pipeline
 
-1. **Deterministic Function Order**: Functions are ordered based on their position in the codebase.
-2. **Block/Loop Replacement**: Blocks and loops are replaced with Br-family instructions.
-3. **Redesigned Break Instructions**: Break instructions now support program counter (PC) offsets instead of depth-level.
-4. **Simplified Binary Verification**: Most sections are removed to streamline binary verification.
-5. **Unified Memory Segment Section**: Implements all WASM memory standards in one place.
-6. **Removed Global Variables Section**: Global variables section is eliminated.
-7. **Eliminated Type Mapping**: Type mapping is no longer necessary as the code is fully validated.
-8. **Special Entrypoint Function**: A unique entry point function encompasses all segments.
+rWASM uses a clear execution pipeline:
 
-The new binary representation ensures a fully equivalently compatible WASMi runtime module from the binary.
-Some features are no longer supported but are not required by the rWASM runtime:
+1. **Input Wasm module**
+2. **Parser + validator**
+3. **rWASM translator/compiler**
+4. **Compact rWASM module artifact**
+5. **Execution strategy** (native rWASM VM, plus optional compatibility strategy)
 
-- Module imports, global variables, and memory imports
-- Global variables exports
+## Core subsystems
 
-## Structure
+### Compiler / translator
 
-The rWASM binary format supports the following sections:
+The compiler layer parses and validates Wasm, then rewrites execution into the rWASM-oriented opcode stream and metadata layout.
 
-1. **Bytecode Section**: Replaces the function/code/entrypoint sections.
-2. **Memory Section**: Replaces memory/data sections for all active/passive/declare section types.
-3. **Function Section**: A temporary solution for the code section, planned for removal.
-4. **Element Section**: Replaces the table/elem sections, also planned for removal.
+### Module model
 
-### Bytecode Section
+rWASM modules are serialized as explicit runtime artifacts consumed by the VM.
+Current format includes a fixed header/magic + ordered sections (code/data/element/hints and source metadata).
 
-This section consolidates WASM's original function, code, and start sections.
-It contains all instructions for the entire binary without any additional separators for functions.
-Functions are recovered from the bytecode by reading the function section, which contains function lengths.
-We inject the entrypoint function at the end, which is used to initialize all segments according to WASM constraints.
+### Opcode model
 
-> **Note**: We plan to remove the function section and store the entrypoint at offset 0. To achieve this, we need to eliminate stack calls and implement indirect breaks. Although we have an implementation for this, it is not yet satisfactory, and we plan to migrate to a register-based IR before finalizing it.
+The opcode surface is explicitly defined and version-sensitive.
 
-### Memory Section
+Important operational rule:
+- opcode ordering and module encoding are wire-compatibility concerns,
+- changing them is a format-level change, not a cosmetic refactor.
 
-In WASM, memory and data sections are handled separately.
-In rWASM, the Memory section defines memory bounds (lower and upper limits), and data sections,
-which can be either active or passive, specify data to be mapped inside the memory.
-Unlike WASM, rWASM eliminates the separate memory section,
-modifies the corresponding instruction logic, and merges all data sections.
+### Runtime VM
 
-Here's an example of a WAT file that initializes memory with minimum and maximum memory bounds
-(default allocated memory is one page, and the maximum possible allocated pages are two):
+The native VM is a stack-machine executor with:
 
-```wat
-(module
-  (memory 1 2)
-)
-```
+- value/call stack transitions,
+- memory/table/global handling,
+- trap model,
+- host import linkage,
+- resumable context hooks.
 
-To support this, we inject the `memory.grow` instruction into the entrypoint to initialize the default memory.
-We also add a special preamble to all `memory.grow` instructions to perform upper bound checks.
+### Strategy abstraction
 
-Here is an example of the resulting entrypoint injection:
+rWASM supports a strategy layer so native execution and compatibility/comparison backends can be selected by feature/runtime setup.
 
-```wat
-(module
-  (func $__entrypoint
-    i32.const $_init_pages
-    memory.init
-    drop)
-)
-```
+## Fuel and metering
 
-According to WASM standards, a memory overflow causes `u32::MAX` to be placed on the stack.
-For upper-bound checks, we can use the `memory.size` opcode.
-Here is an example of such an injection:
+Fuel is a first-class runtime primitive:
 
-```wat
-(module
-  (func $_func_uses_memory_grow
-    (block
-      local.get 1
-      memory.size
-      i32.add
-      i32.const $_max_pages
-      i32.gts
-      drop
-      i32.const 4294967295
-      br 0
-      memory.grow)
-  )
-)
-```
+- bounded mode: deterministic out-of-fuel traps,
+- unbounded mode: for controlled/testing contexts,
+- reset/remaining behavior exposed by runtime store interfaces.
 
-These injections fully comply with WASM standards,
-allowing us to support official WASM memory constraint checks for the memory section.
+Fuel is consumed by both instruction paths and host-mediated operations depending on integration policy.
 
-For the data section, the process is more complex because we need to support three different data section types:
+## Tracing and observability
 
-- **Active**: Has a pre-defined compile-time offset.
-- **Passive**: Can be initialized dynamically at runtime.
+With tracing enabled, runtime emits instruction/memory/table-oriented execution traces for debugging and analysis.
 
-To address this, we merge all sections.
-If the memory is active, we initialize it inside the entrypoint with re-mapped offsets.
-Otherwise,
-we remember the offset in a special mapping to adjust passive segments when the user calls `memory.init` manually.
+This is useful for:
 
-Here is an example of an entrypoint injection for an active data segment:
+- differential checks,
+- profiling,
+- proving/debug instrumentation.
 
-```wat
-(module
-  (func $__entrypoint
-    i32.const $_relative_offset
-    i64.const $_data_offset
-    i64.const $_data_length // or u64::MAX in case of overflow
-    memory.init 0
-    data.drop $segment_index+1
-  )
-)
-```
+## Feature-gated runtime surface
 
-We need to drop the data segment finally.
-According to WASM standards, once the segment is initialized, it must be entirely removed from memory.
-To simulate this behavior,
-we use zero segments as a default and store special data segment flags to know which segments are still active.
+rWASM behavior depends on enabled features (`std`, `wasmtime`, `fpu`, `tracing`, etc.).
+Feature combinations are part of the effective runtime surface and should be pinned in production builds.
 
-For passive data segments, the logic is similar, but we must recalculate data segment offsets on the fly.
+## Security posture (architecture level)
 
-```wat
-(module
-  (func $_func_uses_memory_init
-    // adjust length
-    (block
-      local.get 1
-      local.get 3
-      i32.add
-      i32.const $_data_len
-      i32.gts
-      br_if_eqz 0
-      i32.const 4294967295 // an error
-      local.set 1
-    )
-    // adjust offset
-    i32.const $_data_offset
-    local.get 3
-    i32.add
-    local.set 2
-    // do init
-    memory.init $_segment_index+1
-  )
-)
-```
+Current rWASM docs emphasize:
 
-The provided injections are examples and may vary based on specific requirements.
+- validation-first execution,
+- fail-safe traps and bounds checks,
+- host boundary determinism requirements,
+- DoS controls via size/fuel/resource policies.
 
-### Function Sections (Temporary)
+In practice, VM determinism and host determinism are both required.
+A deterministic VM with nondeterministic host imports is still nondeterministic at system level.
 
-The function section is a temporary measure used to store information about function lengths.
-This section will be removed once we move the entrypoint function to the beginning of the module.
+## Implementation references
 
-Currently, removing functions requires significant refactoring and modifications to our codebase, including:
+For exact, current behavior see:
 
-1. Replacing all functions with breaks (e.g., `br` instructions).
-2. Removing stack calls and using indirect breaks or tables.
-
-We plan to migrate to a register-based VM in the future.
-
-### Element Section (Temporary)
-
-The element section uses the same translation logic as the memory/data sections
-but operates with tables and elements instead of memory and data.
-
-This section is also temporary and will eventually be replaced with memory operations.
-Doing so can reduce the number of read/write operations and the size of our circuits.
-The main challenge is managing memory securely to avoid mixing system and user memory spaces.
-We aim to support original WASM binaries, regardless of how they are compiled,
-without resorting to a custom WASM compilation target.
-
-This approach is still under research.
+- `rwasm/docs/architecture.md`
+- `rwasm/docs/pipeline.md`
+- `rwasm/docs/module-format.md`
+- `rwasm/docs/vm-and-fuel.md`
+- `rwasm/docs/opcodes.md`
+- `rwasm/docs/security-considerations.md`


### PR DESCRIPTION
## Summary
Focused rewrite of the tech-book rWasm section using current `fluentlabs-xyz/rwasm` documentation as the source baseline.

Updated files:
- `src/rwasm/index.md`
- `src/rwasm/motivation.md`
- `src/rwasm/technology.md`
- `src/architecture/blended-vm/rwasm.md`

## Why this change
The previous rWasm text mixed historical implementation details and stale absolute claims (for example fixed compatibility percentages / frozen structure assumptions).
This rewrite aligns the section with current rWasm docs and keeps architecture-level explanations accurate.

## What was improved
- clarified rWasm’s role in Fluent blended execution
- aligned terminology with current rwasm docs (pipeline/module model/VM/fuel/strategy/host boundary)
- removed stale or over-absolute claims and replaced with version-sensitive language where needed
- added explicit source-of-truth guidance to `fluentlabs-xyz/rwasm/docs/*` for implementation details

## Validation
- local markdown link check across `src/**/*.md` (no broken local links)

(Full `mdbook build` was not run in this environment because `mdbook` is unavailable.)
